### PR TITLE
watch for all rationals in calc_part

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -320,7 +320,7 @@ def get_integer_part(expr, no, options, return_ints=False):
     def calc_part(expr, nexpr):
         nint = int(to_int(nexpr, rnd))
         n, c, p, b = nexpr
-        if (c != 1 or n == 1) and p != 0:
+        if p < 0:
             expr = C.Add(expr, -nint, evaluate=False)
             x, _, x_acc, _ = evalf(expr, 10, options)
             try:

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -2,7 +2,8 @@ from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factorial,
                    fibonacci, floor, Function, GoldenRatio, I, Integral,
                    integrate, log, Mul, N, oo, pi, Pow, product, Product,
                    Rational, S, Sum, sin, sqrt, sstr, sympify, Symbol)
-from sympy.core.evalf import complex_accuracy, PrecisionExhausted, scaled_zero
+from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
+    scaled_zero, get_integer_part)
 from sympy.core.compatibility import long
 from mpmath import inf, ninf
 from sympy.abc import n, x, y
@@ -457,7 +458,14 @@ def test_issue_8821_highprec_from_str():
     assert Abs(sin(p)) < 1e-64
 
 
-def test_issue_8853_floor():
-    x = Symbol('x', even=True, negative=True)
-    assert floor(x - S.Half).is_even == False
-    assert floor(x + S.Half).is_even == True
+def test_issue_8853():
+    p = Symbol('x', even=True, positive=True)
+    assert floor(-p - S.Half).is_even == False
+    assert floor(-p + S.Half).is_even == True
+    assert ceiling(p - S.Half).is_even == True
+    assert ceiling(p + S.Half).is_even == False
+
+    assert get_integer_part(S.Half, -1, {}, True) == (0, 0)
+    assert get_integer_part(S.Half, 1, {}, True) == (1, 0)
+    assert get_integer_part(-S.Half, -1, {}, True) == (-1, 0)
+    assert get_integer_part(-S.Half, 1, {}, True) == (0, 0)


### PR DESCRIPTION
The number reresented with n, c, p in calc_part is `[1, -1][n]*c*2**p`
with all n, c, and p integers. A non-integer will have p < 0, so the test for
numbers that need rounding in calc_part is changed from c != 1 and p != 0
(which was an integer when p > 0) to simply p < 0.
